### PR TITLE
Test: Lock e2e Bedrock version

### DIFF
--- a/e2e/scripts/testdata/bedrock_append.txtar
+++ b/e2e/scripts/testdata/bedrock_append.txtar
@@ -1,6 +1,6 @@
 [!composer:2.9] skip 'Subcommand "repo" is added in Composer v2.9'
 
-exec composer create-project --quiet roots/bedrock
+exec composer create-project --quiet roots/bedrock bedrock 1.30.0
 cd bedrock
 
 exec composer config --quiet secure-http false

--- a/e2e/scripts/testdata/bedrock_prepend.txtar
+++ b/e2e/scripts/testdata/bedrock_prepend.txtar
@@ -1,4 +1,4 @@
-exec composer create-project --quiet roots/bedrock
+exec composer create-project --quiet roots/bedrock bedrock 1.30.0
 cd bedrock
 
 exec composer config --quiet secure-http false

--- a/e2e/scripts/testdata/bedrock_santiy.txtar
+++ b/e2e/scripts/testdata/bedrock_santiy.txtar
@@ -1,4 +1,4 @@
-exec composer create-project --quiet roots/bedrock
+exec composer create-project --quiet roots/bedrock bedrock 1.30.0
 cd bedrock
 
 exec composer config --quiet secure-http false


### PR DESCRIPTION
To prevent https://github.com/roots/wp-composer/issues/28 from breaking tests.