### PR TITLE
Run e2e tests against both `https://repo-wpsecadv.typist.tech/` and `https://wpsecadv.fly.dev/`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,3 +35,20 @@ jobs:
           IMAGE: ghcr.io/${{ github.repository }}@sha256:${{ steps.verify.outputs.digest }}
           FLY_APP: ${{ vars.FLY_APP }}
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+  dispatch:
+    needs:
+      - fly
+    permissions:
+      actions: write
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Dispatch Test (e2e Production) Workflow
+        run: |
+          gh workflow run test-e2e-prod.yml \
+            --repo "${REPO}" \
+            --ref "${REF}"
+        env:
+          REPO: ${{ github.repository }}
+          REF: ${{ github.ref_name }}
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/test-e2e-prod.yml
+++ b/.github/workflows/test-e2e-prod.yml
@@ -2,11 +2,6 @@ name: Test (e2e Production)
 
 on:
   workflow_dispatch:
-    inputs:
-      url:
-        description: 'Composer repository URL'
-        required: true
-        default: 'https://repo-wpsecadv.typist.tech/'
   schedule:
     - cron: '34 6,18 * * *' # Twice a day, one hour after the Update Data workflow
 
@@ -23,6 +18,11 @@ env:
 jobs:
   e2e-test-prod:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        url: 
+          - 'https://repo-wpsecadv.typist.tech/'
+          - 'https://wpsecadv.fly.dev/'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -34,4 +34,4 @@ jobs:
 
       - run: go test -tags=e2econtainer -count=1 -shuffle=on ./e2e/container/...
         env:
-          WPSECADV_SERVER_URL: ${{ github.event.inputs.url || 'https://repo-wpsecadv.typist.tech/' }}
+          WPSECADV_SERVER_URL: ${{ matrix.url }}

--- a/e2e/container/main_test.go
+++ b/e2e/container/main_test.go
@@ -4,8 +4,10 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -24,9 +26,75 @@ func TestE2E(t *testing.T) {
 		out = t.Output()
 	}
 
-	srv, err := testcontainers.Run(
-		ctx,
-		"",
+	var opts []testcontainers.ContainerCustomizer
+
+	srvURL := os.Getenv("WPSECADV_SERVER_URL")
+	if srvURL == "" {
+		u, port := bootServer(t, ctx, out)
+		srvURL = u
+		opts = append(opts, testcontainers.WithHostPortAccess(port))
+	}
+	t.Logf("server URL: %s", srvURL)
+
+	tests := []struct {
+		name            string
+		composerVersion string
+	}{
+		{"composer_2.9", "2.9"},
+		{"composer_2.8", "2.8"},
+		{"composer_2.7", "2.7"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			customizers := []testcontainers.ContainerCustomizer{
+				testcontainers.WithName("wpsecadv-e2e-scripts-" + tt.name),
+				testcontainers.WithDockerfile(testcontainers.FromDockerfile{
+					Context:        filepath.Join("..", ".."),
+					Dockerfile:     filepath.Join("e2e", "scripts", "Dockerfile"),
+					Repo:           "localhost/wpsecadv-e2e-scripts",
+					Tag:            tt.name,
+					BuildLogWriter: out,
+					BuildArgs: map[string]*string{
+						"COMPOSER_VERSION": &tt.composerVersion,
+					},
+					KeepImage: true,
+				}),
+				testcontainers.WithEntrypoint("sh", "-c", "echo ready && sleep infinity"),
+				testcontainers.WithWaitStrategy(
+					wait.ForLog("ready"),
+				),
+			}
+			customizers = append(customizers, opts...)
+
+			scripts, err := testcontainers.Run(ctx, "", customizers...)
+			t.Cleanup(func() {
+				err = testcontainers.TerminateContainer(scripts, testcontainers.StopTimeout(10*time.Second))
+				if err != nil {
+					t.Errorf("failed to terminate scripts container: %v", err)
+				}
+			})
+			if err != nil {
+				t.Fatalf("failed to start scripts container: %v", err)
+			}
+
+			cmd := []string{"/app/scripts.test"}
+			if testing.Verbose() {
+				cmd = append(cmd, "-test.v")
+			}
+			exec(t, ctx, scripts, cmd, tcexec.WithEnv([]string{"WPSECADV_SERVER_URL=" + srvURL}))
+		})
+	}
+}
+
+func bootServer(t *testing.T, ctx context.Context, out io.Writer) (string, int) {
+	t.Helper()
+
+	t.Log("starting server via testcontainers")
+
+	srvCustomizers := []testcontainers.ContainerCustomizer{
 		testcontainers.WithName("wpsecadv-e2e-server"),
 		testcontainers.WithDockerfile(testcontainers.FromDockerfile{
 			Context:        filepath.Join("..", ".."),
@@ -39,7 +107,9 @@ func TestE2E(t *testing.T) {
 		testcontainers.WithWaitStrategy(
 			wait.ForHTTP("/up").WithPort("8080/tcp"),
 		),
-	)
+	}
+
+	srv, err := testcontainers.Run(ctx, "", srvCustomizers...)
 	t.Cleanup(func() {
 		err := testcontainers.TerminateContainer(srv, testcontainers.StopTimeout(10*time.Second))
 		if err != nil {
@@ -57,74 +127,17 @@ func TestE2E(t *testing.T) {
 	// TODO: The containers are in the same network.
 	// There should be a way for them to connect without hopping to the host.
 	// Maybe using compose? Maybe using custom networks? Maybe using the container name as the hostname?
-	endpoint := "http://" + net.JoinHostPort(testcontainers.HostInternal, outerPort.Port())
-
-	tests := []struct {
-		name            string
-		composerVersion string
-	}{
-		{"composer_2.9", "2.9"},
-		{"composer_2.8", "2.8"},
-		{"composer_2.7", "2.7"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			var out io.Writer
-			if testing.Verbose() {
-				out = t.Output()
-			}
-
-			scripts, err := testcontainers.Run(
-				ctx,
-				"",
-				testcontainers.WithName("wpsecadv-e2e-scripts-"+tt.name),
-				testcontainers.WithDockerfile(testcontainers.FromDockerfile{
-					Context:        filepath.Join("..", ".."),
-					Dockerfile:     filepath.Join("e2e", "scripts", "Dockerfile"),
-					Repo:           "localhost/wpsecadv-e2e-scripts",
-					Tag:            tt.name,
-					BuildLogWriter: out,
-					BuildArgs: map[string]*string{
-						"COMPOSER_VERSION": &tt.composerVersion,
-					},
-					KeepImage: true,
-				}),
-				testcontainers.WithEntrypoint("sh", "-c", "echo ready && sleep infinity"),
-				testcontainers.WithWaitStrategy(
-					wait.ForLog("ready"),
-				),
-				testcontainers.WithHostPortAccess(outerPort.Int()), // TODO!
-			)
-			t.Cleanup(func() {
-				err = testcontainers.TerminateContainer(scripts, testcontainers.StopTimeout(10*time.Second))
-				if err != nil {
-					t.Errorf("failed to terminate scripts container: %v", err)
-				}
-			})
-			if err != nil {
-				t.Fatalf("failed to start scripts container: %v", err)
-			}
-
-			cmd := []string{"/app/scripts.test"}
-			if testing.Verbose() {
-				cmd = append(cmd, "-test.v")
-			}
-			exec(t, scripts, cmd, tcexec.WithEnv([]string{"WPSECADV_SERVER_URL=" + endpoint}))
-		})
-	}
+	return "http://" + net.JoinHostPort(testcontainers.HostInternal, outerPort.Port()), outerPort.Int()
 }
 
-func exec(t *testing.T, c testcontainers.Container, cmd []string, opts ...tcexec.ProcessOption) {
+func exec(t *testing.T, ctx context.Context, c testcontainers.Container, cmd []string, opts ...tcexec.ProcessOption) {
 	t.Helper()
 
 	var buf bytes.Buffer
 	buf.WriteString("### EXEC ")
 	buf.WriteString(strings.Join(cmd, " "))
 
-	code, out, err := c.Exec(t.Context(), cmd, opts...)
+	code, out, err := c.Exec(ctx, cmd, opts...)
 	if err != nil {
 		t.Fatalf("%s\nfailed to exec command: %v", buf.String(), err)
 	}


### PR DESCRIPTION
- GitHub Actions: Run e2e tests against both https://repo-wpsecadv.typist.tech/ and https://wpsecadv.fly.dev/
- Fix: Test against WPSECADV_SERVER_URL if given
- GitHub Actions: Run e2e tests after deploy